### PR TITLE
fix makefile for libllsm. fix symbol conflicts 

### DIFF
--- a/common.h
+++ b/common.h
@@ -52,20 +52,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #define EPS 0.0000000001
 
-inline void** malloc2d(size_t m, size_t n, size_t size) {
+static inline void** malloc2d(size_t m, size_t n, size_t size) {
   void** ret = calloc(m, sizeof(void*));
   for(size_t i = 0; i < m; i++)
     ret[i] = calloc(n, size);
   return ret;
 }
 
-inline void free2d(void** ptr, size_t m) {
+static inline void free2d(void** ptr, size_t m) {
   for(size_t i = 0; i < m; i ++)
     free(ptr[i]);
   free(ptr);
 }
 
-inline FP_TYPE* fetch_frame(FP_TYPE* x, int nx, int center, int nf) {
+static inline FP_TYPE* fetch_frame(FP_TYPE* x, int nx, int center, int nf) {
   FP_TYPE* y = calloc(nf, sizeof(FP_TYPE));
   for(int i = 0; i < nf; i ++) {
     int isrc = center + i - nf / 2;

--- a/external/matlabfunctions.c
+++ b/external/matlabfunctions.c
@@ -22,11 +22,11 @@
 #define true  1
 typedef int bool;
 
-inline int MyMax(int x, int y) {
+static inline int MyMax(int x, int y) {
   return x > y ? x : y;
 }
 
-inline int MyMin(int x, int y) {
+static inline int MyMin(int x, int y) {
   return x < y ? x : y;
 }
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
-CC = $(CROSS)gcc
+export FP_TYPE ?= float
+CC ?= $(CROSS)gcc
 AR = $(CROSS)ar
-CFLAGS = -DFP_TYPE=float -Ofast -std=c99 -Wall -fPIC $(CFLAGSEXT)
+CFLAGS = -DFP_TYPE=$(FP_TYPE) -Ofast -std=c99 -Wall -fPIC $(CFLAGSEXT)
 ARFLAGS = -rv
 OUT_DIR = ./build
 OBJS = $(OUT_DIR)/math-funcs.o $(OUT_DIR)/yin.o $(OUT_DIR)/pyin.o
@@ -38,4 +39,3 @@ clear:
 	@echo 'Removing all temporary binaries... '
 	@rm -f $(OUT_DIR)/libpyin.a $(OUT_DIR)/*.o
 	@echo Done.
-

--- a/math-funcs.h
+++ b/math-funcs.h
@@ -53,7 +53,7 @@ int      pyin_semitone_from_freq(pyin_semitone_wrapper wrapper, FP_TYPE freq);
 FP_TYPE  pyin_freq_from_semitone(pyin_semitone_wrapper wrapper, int semitone);
 
 #define def_singlepass(name, op, init) \
-inline double name(FP_TYPE* src, int n) { \
+static inline double name(FP_TYPE* src, int n) { \
   FP_TYPE ret = init; \
   for(int i = 0; i < n; i ++) \
     ret = op(ret, src[i]); \
@@ -68,21 +68,21 @@ def_singlepass(sumfp, def_add, 0)
 def_singlepass(maxfp, def_max, src[0])
 def_singlepass(minfp, def_min, src[0])
 
-inline FP_TYPE* hanning(int n) {
+static inline FP_TYPE* hanning(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     ret[i] = 0.5 * (1 - cos(2 * M_PI * i / (n - 1)));
   return ret;
 }
 
-inline FP_TYPE* hamming(int n) {
+static inline FP_TYPE* hamming(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     ret[i] = 0.54 - 0.46 * cos(2 * M_PI * i / (n - 1));
   return ret;
 }
 
-inline FP_TYPE* blackman_harris(int n) {
+static inline FP_TYPE* blackman_harris(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   const FP_TYPE a0 = 0.35875;
   const FP_TYPE a1 = 0.48829;


### PR DESCRIPTION
1. 'inline' will cause symbol conflicts in '-O0'.
2. add FP_TYPE variable in makefile. hardcoded -DFP_TYPE=float will cause a crash in libllsm.
3. support setting compiler by CC environment variable
