### PR TITLE
Add libgvps to submodules, and add it to includepath in Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/libgvps"]
+	path = external/libgvps
+	url = https://github.com/Sleepwalking/libgvps.git

--- a/makefile
+++ b/makefile
@@ -22,8 +22,8 @@ default: $(OUT_DIR)/libpyin.a
 test: $(OUT_DIR)/pyin-test
 	$(OUT_DIR)/pyin-test test/vaiueo2d.wav
 
-$(OUT_DIR)/pyin-test: $(OUT_DIR)/libpyin.a test/test.c external/matlabfunctions.c $(GVPS_PREFIX)/lib/libgvps.a
-	$(CC) $(CFLAGS) -o $(OUT_DIR)/pyin-test test/test.c external/matlabfunctions.c $(OUT_DIR)/libpyin.a $(GVPS_PREFIX)/lib/libgvps.a -lm
+$(OUT_DIR)/pyin-test: $(OUT_DIR)/libpyin.a test/test.c external/matlabfunctions.c $(GVPS_PREFIX)/build/libgvps.a
+	$(CC) $(CFLAGS) -o $(OUT_DIR)/pyin-test test/test.c external/matlabfunctions.c $(OUT_DIR)/libpyin.a $(GVPS_PREFIX)/build/libgvps.a -lm
 
 $(OUT_DIR)/libpyin.a: $(OBJS)
 	$(AR) $(ARFLAGS) $(OUT_DIR)/libpyin.a $(OBJS) $(LIBS)

--- a/makefile
+++ b/makefile
@@ -2,10 +2,10 @@ export FP_TYPE ?= float
 CONFIG = Debug
 
 PREFIX=/usr
-GVPS_PREFIX = /usr
+GVPS_PREFIX = external/libgvps
 CC ?= $(CROSS)gcc
 AR = $(CROSS)ar
-CFLAGS_COMMON = -I$(GVPS_PREFIX)/include -DFP_TYPE=$(FP_TYPE) -std=c99 -Wall -fPIC $(CFLAGSEXT)
+CFLAGS_COMMON = -I$(GVPS_PREFIX) -DFP_TYPE=$(FP_TYPE) -std=c99 -Wall -fPIC $(CFLAGSEXT)
 CFLAGS_DBG = $(CFLAGS_COMMON) -Og -g
 CFLAGS_REL = $(CFLAGS_COMMON) -Ofast
 ifeq ($(CONFIG), Debug)

--- a/pyin.c
+++ b/pyin.c
@@ -31,7 +31,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <libgvps/gvps.h>
+#include <gvps.h>
 #include "math-funcs.h"
 #include "pyin.h"
 

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,8 @@ Compile
 
 ```
 git submodule init
-git submodule update
-cd external/libgvps
-mkdir build
-make
-cd ../..
-mkdir build
+git submodule update --init
+make -C external/libgvps
 make
 ```
 


### PR DESCRIPTION
This PR fixes two things

### 1. Add `libgvps` submodule

The `README` says in order to build this you need to run

    git submodule update --init

However there was no `.gitmodules` file. Now there is one.

### 2. Fix include path to libgvps

Firstly, the include path was incorrect and it is fixed now.

Also, in order for the location of `libgvps` to be portable (some people may not use submodules but instead keep the libraries separate), the build path should not be in the source code, but in a `Makefile` variable. This adds the include path to `libgvps` into `Makefile`, and removes the hardcoded path stub from `pyin.c`