### PR TITLE
fixed GVPS paths and updated README to not reference missing submodules

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,10 +2,10 @@ export FP_TYPE ?= float
 CONFIG = Debug
 
 PREFIX=/usr
-GVPS_PREFIX = /usr
+GVPS_PREFIX = libgvps
 CC ?= $(CROSS)gcc
 AR = $(CROSS)ar
-CFLAGS_COMMON = -I$(GVPS_PREFIX)/include -DFP_TYPE=$(FP_TYPE) -std=c99 -Wall -fPIC $(CFLAGSEXT)
+CFLAGS_COMMON = -I$(GVPS_PREFIX) -DFP_TYPE=$(FP_TYPE) -std=c99 -Wall -fPIC $(CFLAGSEXT)
 CFLAGS_DBG = $(CFLAGS_COMMON) -Og -g
 CFLAGS_REL = $(CFLAGS_COMMON) -Ofast
 ifeq ($(CONFIG), Debug)
@@ -22,8 +22,8 @@ default: $(OUT_DIR)/libpyin.a
 test: $(OUT_DIR)/pyin-test
 	$(OUT_DIR)/pyin-test test/vaiueo2d.wav
 
-$(OUT_DIR)/pyin-test: $(OUT_DIR)/libpyin.a test/test.c external/matlabfunctions.c $(GVPS_PREFIX)/lib/libgvps.a
-	$(CC) $(CFLAGS) -o $(OUT_DIR)/pyin-test test/test.c external/matlabfunctions.c $(OUT_DIR)/libpyin.a $(GVPS_PREFIX)/lib/libgvps.a -lm
+$(OUT_DIR)/pyin-test: $(OUT_DIR)/libpyin.a test/test.c external/matlabfunctions.c $(GVPS_PREFIX)/build/libgvps.a
+	$(CC) $(CFLAGS) -o $(OUT_DIR)/pyin-test test/test.c external/matlabfunctions.c $(OUT_DIR)/libpyin.a $(GVPS_PREFIX)/build/libgvps.a -lm
 
 $(OUT_DIR)/libpyin.a: $(OBJS)
 	$(AR) $(ARFLAGS) $(OUT_DIR)/libpyin.a $(OBJS) $(LIBS)

--- a/pyin.c
+++ b/pyin.c
@@ -31,7 +31,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <libgvps/gvps.h>
+#include <gvps.h>
 #include "math-funcs.h"
 #include "pyin.h"
 

--- a/readme.md
+++ b/readme.md
@@ -7,14 +7,10 @@ Compile
 ---
 
 ```
-git submodule init
-git submodule update
-cd external/libgvps
-mkdir build
-make
-cd ../..
-mkdir build
-make
+git clone https://github.com/Sleepwalking/libgvps.git
+git clone https://github.com/Sleepwalking/libpyin.git
+make -C libgvps
+make GVPS_PREFIX=../libgvps -C libpyin
 ```
 
 Works cited


### PR DESCRIPTION
After your feedback on #7, this PR fixes the include paths to libgvps, and replaces any mention of submodules with an instruction on how to git clone and compile the two libraries.